### PR TITLE
chore: 스키마, 시드데이터 작성 및 오타 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "seed": "ts-node --transpile-only prisma/seed.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/prisma/migrations/20251110094624_fix_column/migration.sql
+++ b/prisma/migrations/20251110094624_fix_column/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `stauts` on the `Complaint` table. All the data in the column will be lost.
+  - You are about to drop the column `paasswordHash` on the `User` table. All the data in the column will be lost.
+  - Added the required column `passwordHash` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Complaint" DROP COLUMN "stauts",
+ADD COLUMN     "status" "ComplaintStatus" NOT NULL DEFAULT 'RECEIVED';
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "paasswordHash",
+ADD COLUMN     "passwordHash" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,7 +49,7 @@ model User {
   id            String   @id @default(uuid())
   name          String
   email         String   @unique
-  paasswordHash String
+  passwordHash String
   role          UserRole @default(RESIDENT)
   createdAt     DateTime @default(now())
   updatedAt     DateTime @default(now())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -134,7 +134,7 @@ model Complaint {
   id          String          @id @default(uuid())
   title       String
   content     String
-  stauts      ComplaintStatus @default(RECEIVED)
+  status      ComplaintStatus @default(RECEIVED)
   userId      String
   apartmentId String
   createdAt   DateTime        @default(now())

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,138 @@
+import {
+  PrismaClient,
+  UserRole,
+  ApartmentStatus,
+  JoinStatus,
+  ComplaintStatus,
+} from '@prisma/client';
+const prisma = new PrismaClient();
+
+async function main() {
+  // SUPER ADMIN
+  const superAdmin = await prisma.user.create({
+    data: {
+      name: '최고관리자',
+      email: 'super@admin.com',
+      passwordHash: 'hashed_pw_super',
+      role: UserRole.SUPER_ADMIN,
+    },
+  });
+
+  // ADMIN
+  const admin = await prisma.user.create({
+    data: {
+      name: '관리자 김철수',
+      email: 'admin@weliv.com',
+      passwordHash: 'hashed_pw_admin',
+      role: UserRole.ADMIN,
+    },
+  });
+
+  // Apartment
+  const apartment = await prisma.apartment.create({
+    data: {
+      name: '위리브 아파트',
+      address: '서울 강남구 어디로 123',
+      description: '신축 아파트입니다.',
+      apartmentStatus: ApartmentStatus.ACTIVE,
+      adminId: admin.id,
+    },
+  });
+
+  // Resident 1 > 가입 승인
+  const residentUser1 = await prisma.user.create({
+    data: {
+      name: '홍길동',
+      email: 'hong@weliv.com',
+      passwordHash: 'hashed_pw_resident1',
+      role: UserRole.RESIDENT,
+    },
+  });
+
+  await prisma.resident.create({
+    data: {
+      userId: residentUser1.id,
+      apartmentId: apartment.id,
+      dong: '101',
+      ho: '1204',
+      joinStatus: JoinStatus.APPROVED,
+    },
+  });
+
+  // Resident 2 > 승인 대기
+  const residentUser2 = await prisma.user.create({
+    data: {
+      name: '이영희',
+      email: 'lee@weliv.com',
+      passwordHash: 'hashed_pw_resident2',
+      role: UserRole.RESIDENT,
+    },
+  });
+
+  await prisma.resident.create({
+    data: {
+      userId: residentUser2.id,
+      apartmentId: apartment.id,
+      dong: '102',
+      ho: '803',
+      joinStatus: JoinStatus.PENDING,
+    },
+  });
+
+  // Notice
+  const notice = await prisma.notice.create({
+    data: {
+      title: '엘리베이터 점검 안내',
+      content: '금주 토요일 오전 9시~12시 점검 예정입니다.',
+      apartmentId: apartment.id,
+    },
+  });
+
+  // Comment
+  await prisma.comment.create({
+    data: {
+      title: '공지 확인',
+      content: '확인했습니다. 감사합니다.',
+      userId: residentUser1.id,
+      noticeId: notice.id,
+    },
+  });
+
+  // Poll with options
+  const poll = await prisma.poll.create({
+    data: {
+      title: '커뮤니티 시설 확장 여부',
+      description: '헬스장/스터디룸 확장에 대한 의견을 묻습니다.',
+      apartmentId: apartment.id,
+      options: {
+        create: [{ text: '확장 찬성' }, { text: '확장 반대' }],
+      },
+    },
+    include: { options: true },
+  });
+
+  // Vote (Resident 1 > 찬성)
+  await prisma.pollVote.create({
+    data: {
+      userId: residentUser1.id,
+      optionId: poll.options[0].id,
+    },
+  });
+
+  // Complaint
+  await prisma.complaint.create({
+    data: {
+      title: '주차장 문제',
+      content: '주차장이 너무 협소합니다. 개선 요청드립니다.',
+      status: ComplaintStatus.RECEIVED,
+      userId: residentUser1.id,
+      apartmentId: apartment.id,
+    },
+  });
+
+  console.log('Seed data inserted successfully!');
+}
+
+main()
+  .catch(console.error)
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## 📝 요약
- 데이터베이스 스키마를 작성했습니다.
- 스키마에 맞는 시드 데이터를 작성했습니다.
- 스키마의 오타를 수정하고 마이그레이션 했습니다.

## 📝 변경사항
- 데이터베이스 스키마 작성
- 시드 데이터 작성

## 📝 추가설명
- SUPER_ADMIN, ADMIN, RESIDENT로 권한 제어
- 한명의 관리자가 아파트를 관리
- 입주민과 해당 아파트를 관계로 묶음 (user-apartment)
- 유저-옵션 중복 투표 방지 기능 추가

## 🔗관련 이슈
- Closes #1 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).